### PR TITLE
Mention Graphviz dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A tool for making deps.edn dependency graphs.
 
 # Usage
 
+First, make sure you have [Graphviz](https://www.graphviz.org/download/) installed.
+
 Add tools.deps.graph as an alias in your ~/.clojure/deps.edn so it's available in any project:
 
 ```clojure


### PR DESCRIPTION
Thanks for creating this handy tool!

Through [dorothy](https://www.graphviz.org/download/) `tools.deps.graph` depends on [Graphviz](https://www.graphviz.org/). Would be nice to mention this in the README.

Since I don't see `toosl.deps.graph` in the [Clojure Jira](https://clojure.atlassian.net/secure/BrowseProjects.jspa) yet, I open this PR as reference.
Feel free to ignore/close/move :slightly_smiling_face: 